### PR TITLE
Update docstring on mapping.py

### DIFF
--- a/hera_cc_utils/mapping.py
+++ b/hera_cc_utils/mapping.py
@@ -227,8 +227,8 @@ class Map(object):
             raw_map = self.data
             nside = healpy.npix2nside(raw_map.size)
         else:
-            # Could add other maps here for backdrops at some point.
-            raise NotImplementedError("help")
+            # Map is not of type np.ndarray 
+            raise NotImplementedError("Map is not of type np.ndarray or is not supported")
 
         # Initialize Rotator object to transform coordinates.
         rot = healpy.Rotator(coord=[coord_in, coord_out], **rot_kw)


### PR DESCRIPTION
The error exception on line 230 occurs when the map is either not supported, or isn't of type np.ndarray. The docstring is updated to reflect that.